### PR TITLE
Support different panic headers

### DIFF
--- a/panicwrap.go
+++ b/panicwrap.go
@@ -222,7 +222,11 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 
 	var panicTimer <-chan time.Time
 	panicBuf := new(bytes.Buffer)
-	panicHeader := []byte("panic:")
+	panicHeaders := [][]byte{
+		[]byte("panic:"),
+		[]byte("fatal error: fault"),
+	}
+	panicType := -1
 
 	tempBuf := make([]byte, 2048)
 	for {
@@ -235,7 +239,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 			// look for another panic along the way.
 
 			// First, remove the previous panic header so we don't loop
-			w.Write(panicBuf.Next(len(panicHeader)))
+			w.Write(panicBuf.Next(len(panicHeaders[panicType])))
 
 			// Next, assume that this is our new buffer to inspect
 			n = panicBuf.Len()
@@ -279,22 +283,27 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 			continue
 		}
 
+		panicType = -1
 		flushIdx := n
-		idx := bytes.Index(buf[0:n], panicHeader)
-		if idx >= 0 {
-			flushIdx = idx
+		for i, header := range panicHeaders {
+			idx := bytes.Index(buf[0:n], header)
+			if idx >= 0 {
+				panicType = i
+				flushIdx = idx
+				break
+			}
 		}
 
 		// Flush to stderr what isn't a panic
 		w.Write(buf[0:flushIdx])
 
-		if idx < 0 {
+		if panicType == -1 {
 			// Not a panic so just continue along
 			continue
 		}
 
 		// We have a panic header. Write we assume is a panic os far.
-		panicBuf.Write(buf[idx:n])
+		panicBuf.Write(buf[flushIdx:n])
 		panicTimer = time.After(dur)
 	}
 }


### PR DESCRIPTION
I have added support for multiple panic headers.

The runtime `fatal error: fault` panic does not start with the text `panic:`, but it does crash the program. I believe panicwrap should also catch this.

Please note that I have not yet written tests for this change, I can't get the tests to work, for which I have opened a different issue(#3). I wanted to open a PR anyway so you could see what I'm working on and maybe give feedback.