### PR TITLE
Forward SIGTERM on UNIX.

### DIFF
--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package panicwrap
+
+import (
+	"os"
+	"syscall"
+)
+
+var WrapSignals []os.Signal = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,0 +1,9 @@
+// +build windows
+
+package panicwrap
+
+import (
+	"os"
+)
+
+var WrapSignals []os.Signal = []os.Signal{os.Interrupt}


### PR DESCRIPTION
SIGINT is generally sent to all processes connected to the virtual terminal when typing Ctrl-C. SIGTERM is generally sent to a single process. In that case, it is wise not to ignore that signal but to forward it to the child process instead to give it the opportunity to handle it.

This is required for correct handling of SIGTERM inside terraform, see hashicorp/terraform#10459. When SIGTERN is sent to the parent process, ignoring the signal won't help, it must be forwarded.

This PR contains a default that depends on the platform for the list of forwarded signals. On UNIX it contains SIGTERM and on Windows, nothing. Possibly the default could be no signal at all by default, and let the panicwrap user choose on its own.