### PR TITLE
Improve signal handling #19

### DIFF
--- a/panicwrap.go
+++ b/panicwrap.go
@@ -172,8 +172,8 @@ func Wrap(c *WrapConfig) (int, error) {
 
 	// Listen to signals and capture them forever. We allow the child
 	// process to handle them in some way.
-	sigCh := make(chan os.Signal)
-	fwdSigCh := make(chan os.Signal)
+	sigCh := make(chan os.Signal, 1)
+	fwdSigCh := make(chan os.Signal, 1)
 	if len(c.IgnoreSignals) == 0 {
 		c.IgnoreSignals = []os.Signal{os.Interrupt}
 	}


### PR DESCRIPTION
It is recommended to buffer channels meant to receive system signals, as the signal won't wait for the channel to be ready to receive, and the channel will therefore miss signals if it wasn't ready.

Could add other changes as suggested in issue #19...