### PR TITLE
Prevent false positives if, after a relaunch, the program tries to execute itself independently of panicwrap

### DIFF
--- a/panicwrap.go
+++ b/panicwrap.go
@@ -227,6 +227,11 @@ func Wrap(c *WrapConfig) (int, error) {
 // Wrapped checks if we're already wrapped according to the configuration
 // given.
 //
+// It must be only called once with a non-nil configuration as it unsets
+// the environment variable it uses to check if we are already wrapped.
+// This prevents false positive if your program tries to execute itself
+// recursively.
+//
 // Wrapped is very cheap and can be used early to short-circuit some pre-wrap
 // logic your application may have.
 //
@@ -251,6 +256,9 @@ func Wrapped(c *WrapConfig) bool {
 	// If the cookie key/value match our environment, then we are the
 	// child, so just exit now and tell the caller that we're the child
 	result := os.Getenv(c.CookieKey) == c.CookieValue
+	if result {
+		os.Unsetenv(c.CookieKey)
+	}
 	wrapCache.Store(result)
 	return result
 }

--- a/panicwrap_test.go
+++ b/panicwrap_test.go
@@ -162,13 +162,13 @@ func TestHelperProcess(*testing.T) {
 
 		if exitStatus < 0 {
 			if child {
-				fmt.Printf("%v", Wrapped(config))
+				fmt.Printf("%v", Wrapped(nil))
 			}
 			os.Exit(0)
 		}
 
 		if !child {
-			fmt.Printf("%v", Wrapped(config))
+			fmt.Printf("%v", Wrapped(nil))
 		}
 		os.Exit(exitStatus)
 	default:


### PR DESCRIPTION
Hi,

An issue as arised from [Terraform](https://github.com/hashicorp/terraform) use of panicwrap.

If, after a relaunch and panicwrap's setup, the application tries to execute itself recursively,
as the cookie env variable will still be set, Wrapped will return true in this new process.

This is an issue for Terraform as they add prefix to the outputs
when Wrapped yield true causing bad outputs.

To solve this I've made it that after we detect that we are indeed in a wrapped process using the env variable, we unset it.

Do you agree with the proposed solution?

You can find the Terraform issue and conversation here https://github.com/hashicorp/terraform/issues/20293