### PR TITLE
Catch all fatal errors

### DIFF
--- a/panicwrap.go
+++ b/panicwrap.go
@@ -280,7 +280,7 @@ func trackPanic(r io.Reader, w io.Writer, dur time.Duration, result chan<- strin
 	panicBuf := new(bytes.Buffer)
 	panicHeaders := [][]byte{
 		[]byte("panic:"),
-		[]byte("fatal error: fault"),
+		[]byte("fatal error:"),
 	}
 	panicType := -1
 


### PR DESCRIPTION
Hello! I believe it would be beneficial to change the panic handlers to catch "fatal errors: sync" in case, for instance, a panic is triggered by an unlocked mutex being unlocked.